### PR TITLE
fix for ORA-03131 on bigendian 64bit machines

### DIFF
--- a/ext/oci8/oci8_statement.c
+++ b/ext/oci8/oci8_statement.c
@@ -1503,6 +1503,10 @@ sb4 php_oci_bind_out_callback(
 
 		/* XXX we assume that zend-zval len has 4 bytes */
 		*alenpp = (ub4*) &Z_STRLEN_P(val);
+		if(sizeof(size_t)==2*sizeof(ub4)){
+			size_t s=1;
+			if(*(ub4*)&s==0) ++*alenpp;
+		}
 		*bufpp = Z_STRVAL_P(val);
 		*piecep = OCI_ONE_PIECE;
 		*rcodepp = &phpbind->retcode;


### PR DESCRIPTION
OCI8 stores the length of retrieved data as a uc4-value into the first 4 bytes of the length of a zend_string (size_t). This fails on bigendian 64bit machines where the length must be stored into the LAST 4 bytes of zend_string-length.
This patches fixes the problem by increasing the *uc4-pointer if the first 4 bytes of (sizte_t)1 are equal to 0.